### PR TITLE
clixon code has "clicon", not "clixon" as the default user

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -33,11 +33,11 @@ Install and build CLIgen::
   make;
   sudo make install
 
-Add a clixon user and group, using useradd and usermod::
+Add a clicon user and group, using useradd and usermod::
    
-  sudo useradd -M -U clixon
-  sudo usermod -a -G clixon <youruser>  # Remember to re-log in for this to take effect
-  sudo usermod -a -G clixon www-data # Only if RESTCONF
+  sudo useradd -M -U clicon
+  sudo usermod -a -G clicon <youruser>  # Remember to re-log in for this to take effect
+  sudo usermod -a -G clicon www-data # Only if RESTCONF
   
 If you do not require RESTCONF, then continue with `Build clixon from source`_.
 


### PR DESCRIPTION
Match what the code does, per configure.ac:

CLICON_USER="clicon"
AC_ARG_WITH([clicon-user], [AS_HELP_STRING([--with-clicon-user=user], [Run as this user in configuration files])], [
  CLICON_USER="$withval"
])
AC_SUBST(CLICON_USER)
if test -n "${CLICON_USER}"; then
    echo "Using CLICON_USER here: ${CLICON_USER}"
fi

CLICON_GROUP="clicon"
AC_ARG_WITH([clicon-group], [AS_HELP_STRING([--with-clicon-group=group], [Run as this group in configuration files])], [
  CLICON_GROUP="$withval"
])
AC_SUBST(CLICON_GROUP)
if test -n "${CLICON_GROUP}"; then
    echo "Using CLICON_GROUP here: ${CLICON_GROUP}"
fi